### PR TITLE
Fix table schema references

### DIFF
--- a/groups.view.lkml
+++ b/groups.view.lkml
@@ -1,5 +1,5 @@
 view: groups {
-  sql_table_name: looker_zendesk.zendesk_groups ;;
+  sql_table_name: zendesk.zendesk_groups ;;
 
   dimension: id {
     primary_key: yes

--- a/organizations.view.lkml
+++ b/organizations.view.lkml
@@ -1,5 +1,5 @@
 view: organizations {
-  sql_table_name: looker_zendesk.organizations ;;
+  sql_table_name: zendesk.organizations ;;
 
   dimension: id {
     primary_key: yes

--- a/tags.view.lkml
+++ b/tags.view.lkml
@@ -1,5 +1,5 @@
 view: tag_types {
-  sql_table_name: looker_zendesk.zendesk_tags ;;
+  sql_table_name: zendesk.zendesk_tags ;;
 
   dimension: count {
     type: number

--- a/ticket_change_details.view.lkml
+++ b/ticket_change_details.view.lkml
@@ -1,5 +1,5 @@
 view: audits__events {
-  sql_table_name: looker_zendesk.audits__events ;;
+  sql_table_name: zendesk.audits__events ;;
 
   dimension: id_change_events {
     primary_key: yes

--- a/ticket_changes.view.lkml
+++ b/ticket_changes.view.lkml
@@ -1,5 +1,5 @@
 view: audits {
-  sql_table_name: looker_zendesk.audits ;;
+  sql_table_name: zendesk.audits ;;
 
   dimension: id {
     primary_key: yes

--- a/ticket_field_names.view.lkml
+++ b/ticket_field_names.view.lkml
@@ -1,5 +1,5 @@
 view: ticket_fields {
-  sql_table_name: looker_zendesk.ticket_fields ;;
+  sql_table_name: zendesk.ticket_fields ;;
 
   dimension: id_field_name {
     primary_key: yes

--- a/ticket_field_values.view.lkml
+++ b/ticket_field_values.view.lkml
@@ -1,5 +1,5 @@
 view: tickets__fields {
-  sql_table_name: looker_zendesk.tickets__fields ;;
+  sql_table_name: zendesk.tickets__fields ;;
 
   dimension: id_field_value {
     primary_key: yes

--- a/ticket_history_audit.view.lkml
+++ b/ticket_history_audit.view.lkml
@@ -4,7 +4,7 @@ view: ticket_history_audit {
         ticket_id
         , count(*) as ticket_actions
         , LAST_VALUE(new_value IGNORE NULLS) OVER (PARTITION BY ticket_id ORDER BY timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as last_value
-      from looker_zendesk.audits__events
+      from zendesk.audits__events
       group by 1, 2, 3
        ;;
   }

--- a/ticket_metrics.view.lkml
+++ b/ticket_metrics.view.lkml
@@ -1,5 +1,5 @@
 view: ticket_metrics {
-  sql_table_name: looker_zendesk.zendesk_ticket_metrics ;;
+  sql_table_name: zendesk.zendesk_ticket_metrics ;;
   #   definition resource: https://developer.zendesk.com/rest_api/docs/core/ticket_metrics
 
   dimension: id {

--- a/ticket_tags_values.view.lkml
+++ b/ticket_tags_values.view.lkml
@@ -1,5 +1,5 @@
 view: ticket__tags {
-  sql_table_name: looker_zendesk.tickets__tags ;;
+  sql_table_name: zendesk.tickets__tags ;;
 
   dimension: ticket_id {
     type: number

--- a/tickets.view.lkml
+++ b/tickets.view.lkml
@@ -1,5 +1,5 @@
 view: tickets {
-  sql_table_name: looker_zendesk.tickets ;;
+  sql_table_name: zendesk.tickets ;;
 
   dimension: id {
     primary_key: yes

--- a/users.view.lkml
+++ b/users.view.lkml
@@ -1,5 +1,5 @@
 view: users {
-  sql_table_name: looker_zendesk.users ;;
+  sql_table_name: zendesk.users ;;
 
   dimension: id {
     primary_key: yes


### PR DESCRIPTION
The default forked repo referenced `looker_zendesk` as the database schema however ours is just `zendesk`. This PR updates all references in LKML files.