### PR TITLE
Join Car, Trip, and User to the Zendesk tickets view

### DIFF
--- a/manifest.lkml
+++ b/manifest.lkml
@@ -1,0 +1,8 @@
+project_name: "stitch_zendesk"
+
+# # Use local_dependency: To enable referencing of another project
+# # on this instance with include: statements
+
+local_dependency: {
+  project: "getaround"
+}


### PR DESCRIPTION
This extends our Stitch Zendesk integration to join in Getaround data. This allows us to examine which users have the highest satisfaction / dissatisfaction. Any chronic problems per car. Tickets per car. And the like.