### PR TITLE
Add ticket counts for CSAT responses

### DIFF
--- a/tickets.view.lkml
+++ b/tickets.view.lkml
@@ -248,6 +248,42 @@ view: tickets {
     }
   }
 
+  measure: count_satisfied {
+    description: "Count tickets marked as \"good\" by the requester"
+    type: count
+    filters: {
+      field: csat_rating
+      value: "good"
+    }
+  }
+
+  measure: count_dissatisfied {
+    description: "Count tickets marked as \"bad\" by the requester"
+    type: count
+    filters: {
+      field: csat_rating
+      value: "bad"
+    }
+  }
+
+  measure: count_offered {
+    description: "Count tickets marked as \"offered\" by the requester"
+    type: count
+    filters: {
+      field: csat_rating
+      value: "offered"
+    }
+  }
+
+  measure: count_unoffered {
+    description: "Count tickets marked as \"unoffered\" by the requester"
+    type: count
+    filters: {
+      field: csat_rating
+      value: "unoffered"
+    }
+  }
+
   ############ TIME FIELDS ###########
 
 #  dimension_group: time {


### PR DESCRIPTION
It's useful to be able to count only tickets with CSAT replies when looking at KPIs. This allows us to look at CSAT data easily without pivoting.