### PR TITLE
Looker/ZD Updates

### DIFF
--- a/ticket_metrics.view.lkml
+++ b/ticket_metrics.view.lkml
@@ -166,12 +166,14 @@ view: ticket_metrics {
 
   dimension: full_resolution_time_in_days__calendar {
     type: number
+    value_format_name: decimal_1
     sql: ${TABLE}.full_resolution_time_in_minutes__calendar / 1440 ;;
   }
 
-  measure: avg_full_resolution_time_in_days__calendar{
+  measure: avg_full_resolution_time_in_days__calendar {
     type: average
-    sql: ${full_resolution_time_in_days__calendar};;
+    value_format_name: decimal_1
+    sql: ${full_resolution_time_in_days__calendar} ;;
   }
 
   dimension_group: initially_assigned {

--- a/ticket_metrics.view.lkml
+++ b/ticket_metrics.view.lkml
@@ -31,7 +31,7 @@ view: ticket_metrics {
 
   dimension: assignee_email {
     type: string
-    sql: ${users.email} ;;
+    sql: ${assignees.email} ;;
   }
 
   dimension: group_name {
@@ -164,14 +164,15 @@ view: ticket_metrics {
     sql: ${full_resolution_time_in_days__business} ;;
   }
 
-  #   - dimension: full_resolution_time_in_days__calendar
-  #     type: number
-  #     sql: ${TABLE}.full_resolution_time_in_minutes__calendar / 1440
-  #
-  #   - measure: avg_full_resolution_time_in_days__calendar
-  #     type: avg
-  #     sql: ${full_resolution_time_in_days__calendar}
+  dimension: full_resolution_time_in_days__calendar{
+    type: number
+    sql: ${TABLE}.full_resolution_time_in_minutes__calendar / 1440;;
+  }
 
+  measure: avg_full_resolution_time_in_days__calendar{
+    type: average
+    sql: ${full_resolution_time_in_days__calendar};;
+  }
 
   dimension_group: initially_assigned {
     type: time

--- a/ticket_metrics.view.lkml
+++ b/ticket_metrics.view.lkml
@@ -164,9 +164,9 @@ view: ticket_metrics {
     sql: ${full_resolution_time_in_days__business} ;;
   }
 
-  dimension: full_resolution_time_in_days__calendar{
+  dimension: full_resolution_time_in_days__calendar {
     type: number
-    sql: ${TABLE}.full_resolution_time_in_minutes__calendar / 1440;;
+    sql: ${TABLE}.full_resolution_time_in_minutes__calendar / 1440 ;;
   }
 
   measure: avg_full_resolution_time_in_days__calendar{

--- a/zendesk.model.lkml
+++ b/zendesk.model.lkml
@@ -215,6 +215,12 @@ explore: tickets {
     relationship: many_to_one
   }
 
+  join: ticket_metrics {
+    type: left_outer
+    sql_on: ${tickets.id} = ${ticket_metrics.ticket_id} ;;
+    relationship: one_to_one
+  }
+
   join: groups {
     type: left_outer
     sql_on: ${tickets.group_id} = ${groups.id} ;;


### PR DESCRIPTION
Looker changes needed for Agent time per trip calculation:
- ticket_metrics: comment-out full_resolution_time_in_days__calendar and avg_full_resolution_time_in_days__calendar
- left join ticket_metrics table to the tickets table,  to establish a relationship between ticket_metrics.solved_at and ticket_custom_fields.sum_total_time_spent fields
- updated table name from ‘user’ to ‘assignee’ to be consistent with how it is renamed in the explore.