### PR TITLE
Remove local dependencies in project

### DIFF
--- a/groups.view.lkml
+++ b/groups.view.lkml
@@ -23,6 +23,7 @@ view: groups {
   }
 
   measure: count {
+    description: "Count Zendesk groups"
     type: count
     drill_fields: [id, name]
   }

--- a/manifest.lkml
+++ b/manifest.lkml
@@ -3,6 +3,6 @@ project_name: "stitch_zendesk"
 # # Use local_dependency: To enable referencing of another project
 # # on this instance with include: statements
 
-local_dependency: {
-  project: "getaround"
-}
+# local_dependency: {
+#   project: "getaround"
+# }

--- a/organizations.view.lkml
+++ b/organizations.view.lkml
@@ -39,6 +39,7 @@ view: organizations {
   }
 
   measure: count {
+    description: "Count Zendesk organizations"
     type: count
     drill_fields: [id, name]
   }

--- a/tags.view.lkml
+++ b/tags.view.lkml
@@ -2,6 +2,7 @@ view: tag_types {
   sql_table_name: zendesk.zendesk_tags ;;
 
   dimension: count {
+    description: "Count Zendesk tags"
     type: number
     sql: ${TABLE}.count ;;
   }

--- a/ticket_change_details.view.lkml
+++ b/ticket_change_details.view.lkml
@@ -76,6 +76,7 @@ view: audits__events {
   }
 
   measure: count {
+    description: "Count Zendesk ticket change details"
     type: count
     drill_fields: [id_change_events, field_name, audits.id, audits.via__source__from__name, audits.via__source__to__name]
   }

--- a/ticket_changes.view.lkml
+++ b/ticket_changes.view.lkml
@@ -25,6 +25,7 @@ view: audits {
   }
 
   measure: count {
+    description: "Count Zendesk ticket changes"
     type: count
     drill_fields: [detail*]
   }

--- a/ticket_custom_fields.view.lkml
+++ b/ticket_custom_fields.view.lkml
@@ -211,4 +211,16 @@ view: ticket_custom_fields {
       field: is_car_related
     }
   }
+
+  measure: count_unique_trips {
+    description: "Unique count of Trip IDs referenced by Zendesk tickets"
+    type:  count_distinct
+    sql:  ${getaround_trip_id} ;;
+  }
+
+  measure: count_unique_cars {
+    description: "Unique count of Car IDs referenced by Zendesk tickets"
+    type:  count_distinct
+    sql:  ${getaround_car_id} ;;
+  }
 }

--- a/ticket_metrics.view.lkml
+++ b/ticket_metrics.view.lkml
@@ -321,6 +321,7 @@ view: ticket_metrics {
   }
 
   measure: count {
+    description: "Count Zendesk ticket metrics"
     type: count
     drill_fields: [id, tickets.via__source__from__name, tickets.id, tickets.via__source__to__name]
   }

--- a/ticket_tags_values.view.lkml
+++ b/ticket_tags_values.view.lkml
@@ -18,6 +18,7 @@ view: ticket__tags {
   }
 
   measure: count {
+    description: "Count Zendesk ticket tag values"
     type: count
     drill_fields: []
   }

--- a/tickets.view.lkml
+++ b/tickets.view.lkml
@@ -160,6 +160,7 @@ view: tickets {
   }
 
   measure: count {
+    description: "Count Zendesk tickets"
     type: count
     drill_fields: [id, requester_email]
   }

--- a/users.view.lkml
+++ b/users.view.lkml
@@ -123,6 +123,7 @@ view: users {
   }
 
   measure: count {
+    description: "Count Zendesk users"
     type: count
     drill_fields: [id, name]
   }

--- a/zendesk.model.lkml
+++ b/zendesk.model.lkml
@@ -2,13 +2,13 @@ connection: "getdata"
 
 # include all the views
 include: "*.view"
-include: "/getaround/getaround_trip.view"
-include: "/getaround/getaround_car.view"
-include: "/getaround/getaround_car_style.view"
-include: "/getaround/getaround_user.view"
-include: "/getaround/getaround_market.view"
-include: "/getaround/getaround_market_timezone.view"
-include: "/getaround/edmunds_*.view"
+# include: "/getaround/getaround_trip.view"
+# include: "/getaround/getaround_car.view"
+# include: "/getaround/getaround_car_style.view"
+# include: "/getaround/getaround_user.view"
+# include: "/getaround/getaround_market.view"
+# include: "/getaround/getaround_market_timezone.view"
+# include: "/getaround/edmunds_*.view"
 
 # include all the dashboards
 include: "*.dashboard"
@@ -102,21 +102,21 @@ explore: tickets {
 
   fields: [
     ALL_FIELDS*,
-    -getaround_car.car_fact_dependent*,
-    -getaround_user.renter_fact_dependent_fields*,
-    -getaround_user.owner_fact_dependent_fields*,
-    -getaround_trip.market_fact_dependent*,
-    -getaround_trip.renter_fact_dependent*,
-    -getaround_trip.car_fact_dependent*,
-    -getaround_trip.insurance_dependent*,
-    -getaround_trip.user_market_dependent*,
-    -getaround_car.closeio_lead_dependent*,
-#    -getaround_car.car_style_dependent*,
-    -getaround_user.stripe_dependent_fields*,
-    -getaround_owner.market_dependent_fields*,
-    -getaround_owner.renter_fact_dependent_fields*,
-    -getaround_owner.owner_fact_dependent_fields*,
-    -getaround_owner.stripe_dependent_fields*
+#     -getaround_car.car_fact_dependent*,
+#     -getaround_user.renter_fact_dependent_fields*,
+#     -getaround_user.owner_fact_dependent_fields*,
+#     -getaround_trip.market_fact_dependent*,
+#     -getaround_trip.renter_fact_dependent*,
+#     -getaround_trip.car_fact_dependent*,
+#     -getaround_trip.insurance_dependent*,
+#     -getaround_trip.user_market_dependent*,
+#     -getaround_car.closeio_lead_dependent*,
+# #    -getaround_car.car_style_dependent*,
+#     -getaround_user.stripe_dependent_fields*,
+#     -getaround_owner.market_dependent_fields*,
+#     -getaround_owner.renter_fact_dependent_fields*,
+#     -getaround_owner.owner_fact_dependent_fields*,
+#     -getaround_owner.stripe_dependent_fields*
   ]
 
   join: ticket_custom_fields {
@@ -126,74 +126,74 @@ explore: tickets {
     relationship: one_to_one
   }
 
-  join: getaround_trip {
-    foreign_key: ticket_custom_fields.getaround_trip_id
-    relationship: many_to_one
-  }
+  # join: getaround_trip {
+  #   foreign_key: ticket_custom_fields.getaround_trip_id
+  #   relationship: many_to_one
+  # }
 
-  join: getaround_user {
-    foreign_key: getaround_trip.renter_id
-    relationship:  many_to_one
-  }
+  # join: getaround_user {
+  #   foreign_key: getaround_trip.renter_id
+  #   relationship:  many_to_one
+  # }
 
-  join: getaround_market {
-    foreign_key: getaround_trip.car_parking_address_postcode
-    relationship: many_to_one
-  }
+  # join: getaround_market {
+  #   foreign_key: getaround_trip.car_parking_address_postcode
+  #   relationship: many_to_one
+  # }
 
-  join: getaround_market_timezone {
-    sql_on: ${getaround_market.market_id} = ${getaround_market_timezone.market_id} AND coalesce(${getaround_market.zone_id},0) = coalesce(${getaround_market_timezone.zone_id},0) ;;
-    relationship: one_to_one
-  }
+  # join: getaround_market_timezone {
+  #   sql_on: ${getaround_market.market_id} = ${getaround_market_timezone.market_id} AND coalesce(${getaround_market.zone_id},0) = coalesce(${getaround_market_timezone.zone_id},0) ;;
+  #   relationship: one_to_one
+  # }
 
-  join: getaround_car {
-    foreign_key: ticket_custom_fields.getaround_car_id
-    relationship: many_to_one
-  }
+  # join: getaround_car {
+  #   foreign_key: ticket_custom_fields.getaround_car_id
+  #   relationship: many_to_one
+  # }
 
-  join: getaround_car_style {
-    foreign_key: getaround_car.id
-    relationship: one_to_one
-  }
+  # join: getaround_car_style {
+  #   foreign_key: getaround_car.id
+  #   relationship: one_to_one
+  # }
 
-  join: getaround_owner
-  {
-    from: getaround_user
-    foreign_key: getaround_trip.renter_id
-    relationship:  many_to_one
-  }
+  # join: getaround_owner
+  # {
+  #   from: getaround_user
+  #   foreign_key: getaround_trip.renter_id
+  #   relationship:  many_to_one
+  # }
 
-  # Edmunds begins #
-  join: edmunds_style {
-    view_label: "Edmunds"
-    sql_on: ${getaround_car.model_style_id} = ${edmunds_style.id} ;;
-    relationship: many_to_one
-  }
+  # # Edmunds begins #
+  # join: edmunds_style {
+  #   view_label: "Edmunds"
+  #   sql_on: ${getaround_car.model_style_id} = ${edmunds_style.id} ;;
+  #   relationship: many_to_one
+  # }
 
-  join: edmunds_engine {
-    view_label: "Edmunds"
-    sql_on: ${edmunds_style.engine_id} = ${edmunds_engine.id} ;;
-    relationship: many_to_one
-  }
+  # join: edmunds_engine {
+  #   view_label: "Edmunds"
+  #   sql_on: ${edmunds_style.engine_id} = ${edmunds_engine.id} ;;
+  #   relationship: many_to_one
+  # }
 
-  join: edmunds_fuel_economy {
-    view_label: "Edmunds"
-    sql_on: ${edmunds_style.fuel_economy_id} = ${edmunds_fuel_economy.id} ;;
-    relationship: many_to_one
-  }
+  # join: edmunds_fuel_economy {
+  #   view_label: "Edmunds"
+  #   sql_on: ${edmunds_style.fuel_economy_id} = ${edmunds_fuel_economy.id} ;;
+  #   relationship: many_to_one
+  # }
 
-  join: edmunds_price {
-    view_label: "Edmunds"
-    sql_on: ${edmunds_style.price_id} = ${edmunds_price.id} ;;
-    relationship: many_to_one
-  }
+  # join: edmunds_price {
+  #   view_label: "Edmunds"
+  #   sql_on: ${edmunds_style.price_id} = ${edmunds_price.id} ;;
+  #   relationship: many_to_one
+  # }
 
-  join: edmunds_category {
-    view_label: "Edmunds"
-    sql_on: ${edmunds_style.category_id} = ${edmunds_category.id} ;;
-    relationship: many_to_one
-  }
-  # Edmunds ends #
+  # join: edmunds_category {
+  #   view_label: "Edmunds"
+  #   sql_on: ${edmunds_style.category_id} = ${edmunds_category.id} ;;
+  #   relationship: many_to_one
+  # }
+  # # Edmunds ends #
 
   join: organizations {
     type: left_outer


### PR DESCRIPTION
Looker has moved to no longer supporting circular project dependencies. Since this project is much more narrow in breadth, it makes more sense to set up a project hierarchy that says:

- `getaround` project can import `stitch-zendesk`
- `stitch-zendesk` does not import `getaround`

This means:

- If you want to relate Getaround data to Zendesk data, use the `getaround` project, where tickets will be joined to either the `Trip` or `Car` entities by their ID.

- If you want to analyze all Zendesk data irrespective of whether it relates to Getaround data or not, use the `stitch-zendesk` project. This project will contain ticket custom field dimensions `getaround_trip_id` and `getaround_car_id` but does not join them to the Getaround entities.

In general, we should follow this project dependency convention:

- `getaround`
  - `stitch-zendesk`
  - `stitch-intercom` (e.g. if it existed)
  - `datablocks-gsod`
  - etc...