### PR TITLE
update ticket tag view

### DIFF
--- a/ticket_tags_values.view.lkml
+++ b/ticket_tags_values.view.lkml
@@ -1,5 +1,25 @@
 view: ticket__tags {
-  sql_table_name: zendesk.tickets__tags ;;
+  derived_table: {
+    sql: SELECT
+        tags._sdc_source_key_id,
+        tags.value,
+        value_aggregate.all_values
+      FROM
+        zendesk.tickets__tags AS tags
+      LEFT JOIN (
+        SELECT
+          _sdc_source_key_id,
+          STRING_AGG(value,
+            ', ') AS all_values
+        FROM
+          zendesk.tickets__tags
+        GROUP BY
+          _sdc_source_key_id) AS value_aggregate
+      ON
+        tags._sdc_source_key_id = value_aggregate._sdc_source_key_id ;;
+    indexes: ["_sdc_source_key_id"]
+    persist_for: "24 hours"
+  }
 
   dimension: ticket_id {
     type: number
@@ -11,6 +31,18 @@ view: ticket__tags {
     description: "Zendesk ticket tag"
     type: string
     sql: ${TABLE}.value ;;
+  }
+
+  dimension: all_values {
+    description: "Concatenated view of all Zendesk ticket tags"
+    type: string
+    sql: ${TABLE}.all_values ;;
+  }
+
+  dimension: is_ticket_closed_by_merge {
+    description: "\"YES\" if the ticket is tagged 'closed_by_merge'"
+    type: yesno
+    sql: ${TABLE}.all_values ILIKE '%closed_by_merge%' ;;
   }
 
   dimension_group: time_ticket_created_at {


### PR DESCRIPTION
Changes made to create an aggregated column that list out all of the ZD ticket tags -- note there can be multiple tags for each unique ticket.  Two new dimensions added - one that is a concatenated view of all tickets and one that is a yes/no to have the ability to filter on tickets that were closed_by_merge.  