### PR TITLE
Zendesk fix

### DIFF
--- a/ticket_custom_fields.view.lkml
+++ b/ticket_custom_fields.view.lkml
@@ -78,9 +78,7 @@ view: ticket_custom_fields {
       LEFT JOIN public.trip AS getaround_trip_a
         ON (getaround_trip_a.coalesced_id = ticket_custom_fields.value_trip_id::text)
       LEFT JOIN public.trip AS getaround_trip_b
-        ON (getaround_trip_b.id = ticket_custom_fields.value_trip_id::text)
-      WHERE
-        value_trip_id IS NOT NULL ;;
+        ON (getaround_trip_b.id = ticket_custom_fields.value_trip_id::text) ;;
     indexes: ["ticket_id",
               "value_trip_id",
               "value_car_id"]


### PR DESCRIPTION
Currently, we are only able to view custom fields for tickets related to trips, due to this WHERE clause::
WHERE
        value_trip_id IS NOT NULL ;;

I removed this so that we are no longer limiting the result set to tickets associated with trips.