### PR TITLE
Updates to `first_group` logic and addition of new dimension (public comment feed)

### DIFF
--- a/ticket_facts.view.lkml
+++ b/ticket_facts.view.lkml
@@ -21,7 +21,8 @@ view: ticket_facts {
           COUNT(DISTINCT audits.id) FILTER(WHERE events.type = 'Comment' AND events.public = false)  AS number_internal_comments,
           COUNT(DISTINCT audits.id) FILTER(WHERE audits.via__source__rel = 'merge' and audits.via__source__from__ticket_id IS NULL) AS number_merged_tickets,
           COUNT(DISTINCT audits.id) FILTER(WHERE audits.via__source__rel = 'merge' and audits.via__source__from__ticket_id IS NOT NULL)  AS is_ticket_merged,
-          COUNT(DISTINCT tickets.id) FILTER(WHERE tickets.via__channel = 'api') AS is_programmatically_created
+          COUNT(DISTINCT tickets.id) FILTER(WHERE tickets.via__channel = 'api') AS is_programmatically_created,
+          STRING_AGG(body,'       New Comment:       ') FILTER(WHERE (events.type = 'Comment' AND events.public = true)) AS public_comment_text
 
         FROM
         zendesk_stitch.ticket_audits AS audits
@@ -213,6 +214,12 @@ view: ticket_facts {
       group_label: "Ticket Details"
       type: yesno
       sql: ${TABLE}.is_programmatically_created > 0 ;;
+    }
+
+    dimension: public_comment_text {
+      description: "Concatenation of all public assignee and requester comments associated with this ticket."
+      type: string
+      sql: ${TABLE}.public_comment_text ;;
     }
 
   ### Measures

--- a/ticket_touches_groups.view.lkml
+++ b/ticket_touches_groups.view.lkml
@@ -33,7 +33,7 @@ view: ticket_group_touches {
     description: "The name of the first group the ticket was assigned to"
     view_label: "Ticket First Touch"
     type: string
-    sql: ${TABLE}.first_group ;;
+    sql: COALESCE(${TABLE}.first_group,${tickets.group_name}) ;;
   }
 
   dimension: last_group {

--- a/ticket_touches_groups.view.lkml
+++ b/ticket_touches_groups.view.lkml
@@ -32,7 +32,7 @@ view: ticket_group_touches {
     description: "The name of the first group the ticket was assigned to"
     view_label: "Ticket First Touch"
     type: string
-    sql: ${TABLE}.first_group ;;
+    sql: COALESCE(${TABLE}.first_group, ${tickets.group_name}) ;;
   }
 
   dimension: last_group {

--- a/users.view.lkml
+++ b/users.view.lkml
@@ -19,7 +19,7 @@ view: users {
     group_label: "Time Created At"
     label: "Created At"
     type: time
-    hidden: yes
+    hidden: no
     timeframes: [
       time,
       date,


### PR DESCRIPTION
@xiaolong Can you please review?

Changes include:
- Updating the logic of `first_group` associated with a ticket.  Logic did not work for tickets that come in through our web form. 

- Creating a string of all public comments.  This field will help managers quickly review what is going on with tickets.