### PR TITLE
Age BPO Cohort Weeks

### DIFF
--- a/ticket_metrics.view.lkml
+++ b/ticket_metrics.view.lkml
@@ -415,6 +415,14 @@ view: ticket_metrics {
     sql: ${TABLE}.ticket_id ;;
   }
 
+  dimension: age_bpo_cohort_weeks {
+    label: "Age BPO Cohort Weeks"
+    description: "Age when the BPO agent solved ticket, measured in weeks since cohort start date"
+    type: number
+    sql:  EXTRACT(day from (DATE_TRUNC('week', ${ticket_metrics.time_solved_at_raw})
+      - DATE_TRUNC('week', ${ticket_last_assignee.time_bpo_cohort_start_at_raw})))/7 ;;
+  }
+
   ### Measures
 
   measure: count {

--- a/users.view.lkml
+++ b/users.view.lkml
@@ -78,8 +78,24 @@ view: users {
     label: "BPO Cohort"
     description: "Cohort identifier for third-party service provider. This field will be a combination of the agent's start date and starting location."
     type: string
-    sql: ${TABLE}.user_fields__bpo_start_date ;;
+    sql: ${TABLE}.user_fields__bpo_start_date::DATE ;;
   }
+
+  dimension_group: time_bpo_cohort_start_at {
+    description: "Week that the third-party service provider started. This field is used to define BPO cohorts"
+    group_label: "Time BPO Cohort Start At"
+    label: "BPO Cohort Start At"
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      year
+    ]
+    sql: ${TABLE}.user_fields__bpo_start_date::DATE ;;
+  }
+
 
   ### Measures
 

--- a/users.view.lkml
+++ b/users.view.lkml
@@ -87,6 +87,7 @@ view: users {
       year
     ]
     sql: ${TABLE}.user_fields__bpo_start_date::DATE ;;
+    convert_tz: no
   }
 
 

--- a/users.view.lkml
+++ b/users.view.lkml
@@ -75,7 +75,7 @@ view: users {
   }
 
   dimension_group: time_bpo_cohort_start_at {
-    description: "Week that the third-party service provider started. This field is used to define BPO cohorts"
+    description: "Week that the third-party service provider started, used to define BPO cohorts.  This is a user-created field and doesn't have a specific timezone."
     group_label: "Time BPO Cohort Start At"
     label: "BPO Cohort Start At"
     type: time

--- a/users.view.lkml
+++ b/users.view.lkml
@@ -74,13 +74,6 @@ view: users {
     sql: ${TABLE}.user_fields__team_lead ;;
   }
 
-  dimension: bpo_cohort {
-    label: "BPO Cohort"
-    description: "Cohort identifier for third-party service provider. This field will be a combination of the agent's start date and starting location."
-    type: string
-    sql: ${TABLE}.user_fields__bpo_start_date::DATE ;;
-  }
-
   dimension_group: time_bpo_cohort_start_at {
     description: "Week that the third-party service provider started. This field is used to define BPO cohorts"
     group_label: "Time BPO Cohort Start At"


### PR DESCRIPTION
This PR does two things:

- Refactors the BPO Cohort to cast it as a date and report out as a dimension group.  Note we should not be converting this by timezone.  This field is a user input, and is reported most granularly at the week level.

- Creates `Age BPO Cohort Weeks`: Allows us to report on the difference between when a BPO cohort started and when the tickets were solved (needed for cohort analysis)