### PR TITLE
Create trip related dimensions

### DIFF
--- a/tickets.view.lkml
+++ b/tickets.view.lkml
@@ -282,16 +282,16 @@ view: tickets {
            ELSE NULL END;;
   }
 
-  dimension: is_created_during_trip {
-    description: "'Yes' if ticket was created between 30 minutes prior to trip start time and 30 minutes post the final trip end time."
+  dimension: is_created_in_trip {
+    description: "'Yes' if ticket is created between 30 minutes prior to trip start time and 30 minutes post the final trip end time."
     group_label: "Trip"
     type: yesno
     sql: ${time_created_at_raw} >= (${getaround_trip.time_start_at_raw} - INTERVAL '30 minutes')
       AND ${time_created_at_raw} <= (${getaround_trip.time_end_at_raw} + INTERVAL '30 minutes') ;;
   }
 
-  dimension: is_created_during_trip_extension_period {
-    description: "'Yes' if ticket was created between the trip's original end time and the trip final extension's end time."
+  dimension: is_created_in_trip_extension {
+    description: "'Yes' if ticket is created between the trip's original end time and the trip final extension's end time."
     group_label: "Trip"
     type: yesno
     sql: ${time_created_at_raw} >= (${getaround_trip.time_original_end_at_raw})
@@ -299,7 +299,7 @@ view: tickets {
   }
 
   dimension: is_created_at_trip_start {
-    description: "'Yes' if ticket was created 30 minutes before or after the trip's start time"
+    description: "'Yes' if ticket is created 30 minutes before or after the trip's start time"
     group_label: "Trip"
     type: yesno
     sql: ${time_created_at_raw} >= (${getaround_trip.time_start_at_raw} - INTERVAL '30 minutes')
@@ -307,7 +307,7 @@ view: tickets {
   }
 
   dimension: is_created_at_original_end_time {
-    description: "'Yes' if ticket was created 30 minutes before or after the trip's original end time"
+    description: "'Yes' if ticket is created 30 minutes before or after the trip's original end time"
     group_label: "Trip"
     type: yesno
     sql: ${time_created_at_raw} >= (${getaround_trip.time_original_end_at_raw} - INTERVAL '30 minutes')
@@ -315,7 +315,7 @@ view: tickets {
   }
 
   dimension: is_created_at_trip_creation_time {
-    description: "'Yes' if ticket was created 30 minutes before or after the trip's created at time"
+    description: "'Yes' if ticket is created 30 minutes before or after the trip's created at time"
     group_label: "Trip"
     type: yesno
     sql: ${time_created_at_raw} >= (${getaround_trip.time_created_at_raw} - INTERVAL '30 minutes')
@@ -436,8 +436,8 @@ view: tickets {
 
   set: getaround_trip_dependent_fields {
     fields: [
-      is_created_during_trip,
-      is_created_during_trip_extension_period,
+      is_created_in_trip,
+      is_created_in_trip_extension,
       is_created_at_trip_start,
       is_created_at_original_end_time,
       is_created_at_trip_creation_time,

--- a/tickets.view.lkml
+++ b/tickets.view.lkml
@@ -282,6 +282,46 @@ view: tickets {
            ELSE NULL END;;
   }
 
+  dimension: is_created_during_trip {
+    description: "'Yes' if ticket was created between 30 minutes prior to trip start time and 30 minutes post the final trip end time."
+    group_label: "Trip"
+    type: yesno
+    sql: ${time_created_at_raw} >= (${getaround_trip.time_start_at_raw} - INTERVAL '30 minutes')
+      AND ${time_created_at_raw} <= (${getaround_trip.time_end_at_raw} + INTERVAL '30 minutes') ;;
+  }
+
+  dimension: is_created_during_trip_extension_period {
+    description: "'Yes' if ticket was created between the trip's original end time and the trip final extension's end time."
+    group_label: "Trip"
+    type: yesno
+    sql: ${time_created_at_raw} >= (${getaround_trip.time_original_end_at_raw})
+      AND ${time_created_at_raw} <= (${getaround_trip.time_end_at_raw}) ;;
+  }
+
+  dimension: is_created_at_trip_start {
+    description: "'Yes' if ticket was created 30 minutes before or after the trip's start time"
+    group_label: "Trip"
+    type: yesno
+    sql: ${time_created_at_raw} >= (${getaround_trip.time_start_at_raw} - INTERVAL '30 minutes')
+      AND ${time_created_at_raw} <= (${getaround_trip.time_start_at_raw} + INTERVAL '30 minutes') ;;
+  }
+
+  dimension: is_created_at_original_end_time {
+    description: "'Yes' if ticket was created 30 minutes before or after the trip's original end time"
+    group_label: "Trip"
+    type: yesno
+    sql: ${time_created_at_raw} >= (${getaround_trip.time_original_end_at_raw} - INTERVAL '30 minutes')
+      AND ${time_created_at_raw} <= (${getaround_trip.time_original_end_at_raw} + INTERVAL '30 minutes') ;;
+  }
+
+  dimension: is_created_at_trip_creation_time {
+    description: "'Yes' if ticket was created 30 minutes before or after the trip's created at time"
+    group_label: "Trip"
+    type: yesno
+    sql: ${time_created_at_raw} >= (${getaround_trip.time_created_at_raw} - INTERVAL '30 minutes')
+      AND ${time_created_at_raw} <= (${getaround_trip.time_created_at_raw} + INTERVAL '30 minutes') ;;
+  }
+
   ### Measures
 
   measure: count {
@@ -391,6 +431,16 @@ view: tickets {
       type,
       via__channel,
       subject
+    ]
+  }
+
+  set: getaround_trip_dependent_fields {
+    fields: [
+      is_created_during_trip,
+      is_created_during_trip_extension_period,
+      is_created_at_trip_start,
+      is_created_at_original_end_time,
+      is_created_at_trip_creation_time,
     ]
   }
 }

--- a/tickets.view.lkml
+++ b/tickets.view.lkml
@@ -287,40 +287,40 @@ view: tickets {
     description: "'Yes' if ticket is created between 30 minutes prior to trip start time and 30 minutes post the final trip end time."
     group_label: "Trip"
     type: yesno
-    sql: ${time_created_at_raw} >= (${getaround_trip.time_start_at_raw} - INTERVAL '30 minutes')
-      AND ${time_created_at_raw} <= (${getaround_trip.time_end_at_raw} + INTERVAL '30 minutes') ;;
+    sql: ${time_created_at_utc_raw} >= (${getaround_trip.time_start_at_utc_raw} - INTERVAL '30 minutes')
+      AND ${time_created_at_utc_raw} <= (${getaround_trip.time_end_at_utc_raw} + INTERVAL '30 minutes') ;;
   }
 
   dimension: is_created_in_trip_extension {
-    description: "'Yes' if ticket is created between the trip's original end time and the trip final extension's end time."
+    description: "'Yes' if ticket is created between the trip's original end time and 30 minutes post the trip final extension's end time."
     group_label: "Trip"
     type: yesno
-    sql: ${time_created_at_raw} >= (${getaround_trip.time_original_end_at_raw})
-      AND ${time_created_at_raw} <= (${getaround_trip.time_end_at_raw}) ;;
+    sql: ${time_created_at_utc_raw} >= (${getaround_trip.time_original_end_at_utc_raw})
+      AND ${time_created_at_utc_raw} <= (${getaround_trip.time_end_at_utc_raw} + INTERVAL '30 minutes') ;;
   }
 
   dimension: is_created_at_trip_start {
     description: "'Yes' if ticket is created 30 minutes before or after the trip's start time"
     group_label: "Trip"
     type: yesno
-    sql: ${time_created_at_raw} >= (${getaround_trip.time_start_at_raw} - INTERVAL '30 minutes')
-      AND ${time_created_at_raw} <= (${getaround_trip.time_start_at_raw} + INTERVAL '30 minutes') ;;
+    sql: ${time_created_at_utc_raw} >= (${getaround_trip.time_start_at_utc_raw} - INTERVAL '30 minutes')
+      AND ${time_created_at_utc_raw} <= (${getaround_trip.time_start_at_utc_raw} + INTERVAL '30 minutes') ;;
   }
 
   dimension: is_created_at_original_end_time {
     description: "'Yes' if ticket is created 30 minutes before or after the trip's original end time"
     group_label: "Trip"
     type: yesno
-    sql: ${time_created_at_raw} >= (${getaround_trip.time_original_end_at_raw} - INTERVAL '30 minutes')
-      AND ${time_created_at_raw} <= (${getaround_trip.time_original_end_at_raw} + INTERVAL '30 minutes') ;;
+    sql: ${time_created_at_utc_raw} >= (${getaround_trip.time_original_end_at_utc_raw} - INTERVAL '30 minutes')
+      AND ${time_created_at_utc_raw} <= (${getaround_trip.time_original_end_at_utc_raw} + INTERVAL '30 minutes') ;;
   }
 
   dimension: is_created_at_trip_creation_time {
     description: "'Yes' if ticket is created 30 minutes before or after the trip's created at time"
     group_label: "Trip"
     type: yesno
-    sql: ${time_created_at_raw} >= (${getaround_trip.time_created_at_raw} - INTERVAL '30 minutes')
-      AND ${time_created_at_raw} <= (${getaround_trip.time_created_at_raw} + INTERVAL '30 minutes') ;;
+    sql: ${time_created_at_utc_raw} >= (${getaround_trip.time_created_at_utc_raw} - INTERVAL '30 minutes')
+      AND ${time_created_at_utc_raw} <= (${getaround_trip.time_created_at_utc_raw} + INTERVAL '30 minutes') ;;
   }
 
   ### Measures

--- a/zendesk.model.lkml
+++ b/zendesk.model.lkml
@@ -12,6 +12,10 @@ explore: users {
 }
 
 explore: tickets {
+  fields: [
+    ALL_FIELDS*,
+    -tickets.getaround_trip_dependent_fields*
+  ]
   join: ticket_custom_fields {
     type: left_outer
     foreign_key: tickets.id


### PR DESCRIPTION
This PR creates four new dimensions, which will allow us to report on interesting differences between trip-related timestamps and ticket-related timestamps.   

New dimensions include:
`is_created_in_trip ` , `is_created_in_trip_extension`,  `is_created_at_trip_start`,   `is_created_at_original_end_time`, and `is_created_at_trip_creation_time`